### PR TITLE
Fix: Responsive height in home page

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 
 export default function Page() {
   return (
-    <div className="mt-16 flex h-[calc(100vh-(65px+64px))]">
+    <div className="mt-16 flex min-h-[calc(100vh-(65px+64px))]">
       <div className="border-border relative z-10 mx-auto flex h-full w-full max-w-7xl flex-col items-center justify-center gap-8 border border-b-0 text-center">
         <Image
           src="/home-background.png"


### PR DESCRIPTION
### Problem
The home page was using a fixed height (`h-[calc(100vh-(65px+64px))]`) which caused content to be cut off on smaller screens or when content overflowed beyond the calculated viewport height.

### Solution
Changed from `h-[calc(...)]` to `min-h-[calc(...)]` to allow the container to expand when needed while still maintaining the minimum height for proper layout.

### Changes
- `apps/web/app/(home)/page.tsx`: Updated container div to use `min-h` instead of `h`

This ensures the home page content is always fully visible regardless of screen size or content length, while preserving the intended minimum height layout.