### PR TITLE
Fix icon of the app pointed wrong

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   description:
     'A platform for open source project discovery, collaboration, and growth - connecting project owners with contributors.',
   icons: {
-    icon: '/favicon.ico',
+    icon: '/icon.svg',
   },
 };
 


### PR DESCRIPTION
While browsing the app I noticed there is no icon and check the code it was looking for `favicon.ico` which not available in this repo so I update it to point to correct one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the site icon to use a new SVG icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->