### PR TITLE
Increase project avatar resolutions from 32x32 and 48x48 to 128x128

### DIFF
--- a/apps/web/app/(public)/(projects)/projects/[id]/project-page.tsx
+++ b/apps/web/app/(public)/(projects)/projects/[id]/project-page.tsx
@@ -127,8 +127,8 @@ export default function ProjectPage({ id }: { id: string }) {
                       `https://${project.gitHost}.com${repo?.namespace?.avatar_url}`
                     }
                     alt={project.name ?? 'Project Logo'}
-                    width={48}
-                    height={48}
+                    width={256}
+                    height={256}
                     className="h-12 w-12 rounded-full sm:h-16 sm:w-16"
                   />
                 ) : null}

--- a/apps/web/app/(public)/(projects)/projects/project-card.tsx
+++ b/apps/web/app/(public)/(projects)/projects/project-card.tsx
@@ -43,8 +43,8 @@ export default function ProjectCard({ project }: { project: Project }) {
             <Image
               src={repo?.owner?.avatar_url || `https://gitlab.com${repo?.namespace?.avatar_url}`}
               alt={project.name ?? 'Project Logo'}
-              width={32}
-              height={32}
+              width={256}
+              height={256}
               className="h-10 w-10 flex-shrink-0 rounded-full md:h-12 md:w-12"
             />
           ) : (


### PR DESCRIPTION
| Before 🫨 | After 🤓 |
|--------|--------|
| ![](https://github.com/user-attachments/assets/940e22e4-34e2-4a64-8390-aca07919227f) | ![](https://github.com/user-attachments/assets/ce8e5a51-e49b-4dd8-9914-6a67954389f2) |
| ![](https://github.com/user-attachments/assets/5670458b-c2b1-4a17-80dc-90c790c584e2) | ![](https://github.com/user-attachments/assets/c4960301-7d6e-4bd8-8131-a2f5bf9d2a9a) | 

**Note:** Because the render size is being overridden by tailwind utilities, this has no effect on the actual display size, only the resolution.