### PR TITLE
Feat/quick db seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:generate": "turbo run db:generate",
     "db:migrate": "dotenv -- turbo run db:migrate",
     "db:push": "dotenv -- turbo run db:push",
-    "db:studio": "dotenv -- turbo run db:studio"
+    "db:studio": "dotenv -- turbo run db:studio",
+    "db:seed": "dotenv -- turbo run db:seed"
   },
   "devDependencies": {
     "@workspace/eslint-config": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
+    "db:seed": "bun --conditions=react-server run src/seed/seed-db.ts",
     "format": "prettier --write \"**/*.{ts,tsx,css,,md}\""
   },
   "dependencies": {

--- a/packages/db/src/seed/create-fixture.ts
+++ b/packages/db/src/seed/create-fixture.ts
@@ -1,0 +1,29 @@
+import { PgTableWithColumns } from 'drizzle-orm/pg-core';
+import { getTableName } from 'drizzle-orm';
+import { type DB } from '..';
+
+/**
+ * Provides a type-safe way to create a fixture for a table.
+ */
+export function fixture<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TTable extends PgTableWithColumns<any>, // this type isn't ideal but it doesn't really matter
+>(table: TTable) {
+  return {
+    data(data: TTable['$inferInsert'][]) {
+      return {
+        async run(db: DB) {
+          const tableName = getTableName(table);
+          // this is very simplified, ideally this would run in a transaction
+          // however for proper seeding we should use drizzle migrations
+          try {
+            await db.insert(table).values(data);
+            console.log(`✅ Seeded ${tableName} with ${data.length} records`);
+          } catch (error) {
+            console.error(`❌ Error seeding fixture ${tableName}:`, error);
+          }
+        },
+      };
+    },
+  };
+}

--- a/packages/db/src/seed/fixtures/category.ts
+++ b/packages/db/src/seed/fixtures/category.ts
@@ -1,5 +1,5 @@
+import { categoryTags, categoryProjectTypes, categoryProjectStatuses } from '../../schema';
 import { fixture } from '../create-fixture';
-import { categoryTags } from '../../schema';
 
 export const categoryTagsData = fixture(categoryTags).data([
   {
@@ -34,8 +34,6 @@ export const categoryTagsData = fixture(categoryTags).data([
   },
 ]);
 
-import { categoryProjectTypes } from '../../schema';
-
 export const categoryProjectTypesData = fixture(categoryProjectTypes).data([
   {
     name: 'fintech',
@@ -68,8 +66,6 @@ export const categoryProjectTypesData = fixture(categoryProjectTypes).data([
     sortOrder: 50,
   },
 ]);
-
-import { categoryProjectStatuses } from '../../schema';
 
 export const categoryProjectStatusesData = fixture(categoryProjectStatuses).data([
   {

--- a/packages/db/src/seed/fixtures/category.ts
+++ b/packages/db/src/seed/fixtures/category.ts
@@ -1,0 +1,99 @@
+import { fixture } from '../create-fixture';
+import { categoryTags } from '../../schema';
+
+export const categoryTagsData = fixture(categoryTags).data([
+  {
+    name: 'web',
+    displayName: 'Web Development',
+    isActive: true,
+    sortOrder: 10,
+  },
+  {
+    name: 'mobile',
+    displayName: 'Mobile Apps',
+    isActive: true,
+    sortOrder: 20,
+  },
+  {
+    name: 'ai',
+    displayName: 'Artificial Intelligence',
+    isActive: true,
+    sortOrder: 30,
+  },
+  {
+    name: 'devtools',
+    displayName: 'Developer Tools',
+    isActive: true,
+    sortOrder: 40,
+  },
+  {
+    name: 'cloud',
+    displayName: 'Cloud Services',
+    isActive: true,
+    sortOrder: 50,
+  },
+]);
+
+import { categoryProjectTypes } from '../../schema';
+
+export const categoryProjectTypesData = fixture(categoryProjectTypes).data([
+  {
+    name: 'fintech',
+    displayName: 'Financial Technology',
+    isActive: true,
+    sortOrder: 10,
+  },
+  {
+    name: 'healthtech',
+    displayName: 'Health Technology',
+    isActive: true,
+    sortOrder: 20,
+  },
+  {
+    name: 'edtech',
+    displayName: 'Education Technology',
+    isActive: true,
+    sortOrder: 30,
+  },
+  {
+    name: 'ecommerce',
+    displayName: 'E-Commerce',
+    isActive: true,
+    sortOrder: 40,
+  },
+  {
+    name: 'productivity',
+    displayName: 'Productivity',
+    isActive: true,
+    sortOrder: 50,
+  },
+]);
+
+import { categoryProjectStatuses } from '../../schema';
+
+export const categoryProjectStatusesData = fixture(categoryProjectStatuses).data([
+  {
+    name: 'active',
+    displayName: 'Active',
+    isActive: true,
+    sortOrder: 10,
+  },
+  {
+    name: 'inactive',
+    displayName: 'Inactive',
+    isActive: true,
+    sortOrder: 20,
+  },
+  {
+    name: 'archived',
+    displayName: 'Archived',
+    isActive: true,
+    sortOrder: 30,
+  },
+  {
+    name: 'featured',
+    displayName: 'Featured',
+    isActive: true,
+    sortOrder: 40,
+  },
+]);

--- a/packages/db/src/seed/fixtures/index.ts
+++ b/packages/db/src/seed/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './category';

--- a/packages/db/src/seed/seed-db.ts
+++ b/packages/db/src/seed/seed-db.ts
@@ -1,0 +1,29 @@
+import * as fixtures from './fixtures';
+import { db } from '..';
+
+export async function seedDb() {
+  console.log('🌱 Seeding database...');
+
+  for (const fixtureName of Object.keys(fixtures)) {
+    const fixture = fixtures[fixtureName as keyof typeof fixtures];
+    if ('run' in fixture && typeof fixture.run === 'function') {
+      await fixture.run(db);
+      console.log(`✅ Seeded fixture: ${fixtureName}`);
+    } else {
+      console.warn(
+        `Skipping fixture ${fixtureName} as it may not be properly defined. Make sure to use fixture() to create fixtures.`,
+      );
+    }
+  }
+
+  console.log('✅ Database seeded successfully!');
+  process.exit(0);
+}
+
+seedDb()
+  .then(() => {})
+  .catch((error) => {
+    // catch any unhandled errors
+    console.error('❌ Unexpected error:', error);
+    process.exit(1);
+  });

--- a/packages/db/src/seed/seed-db.ts
+++ b/packages/db/src/seed/seed-db.ts
@@ -20,10 +20,8 @@ export async function seedDb() {
   process.exit(0);
 }
 
-seedDb()
-  .then(() => {})
-  .catch((error) => {
-    // catch any unhandled errors
-    console.error('❌ Unexpected error:', error);
-    process.exit(1);
-  });
+seedDb().catch((error) => {
+  // catch any unhandled errors
+  console.error('❌ Unexpected error:', error);
+  process.exit(1);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -33,6 +33,10 @@
       "persistent": true,
       "cache": false,
       "inputs": ["$TURBO_DEFAULT$", ".env*"]
+    },
+    "db:seed": {
+      "cache": false,
+      "inputs": ["$TURBO_DEFAULT$", ".env*"]
     }
   }
 }


### PR DESCRIPTION
This pull request adds a type-safe database seeding script as long as you define them with `fixture().data()`

You can run it via `bun db:seed` at the root. Running from package won't work bcs of env vars.

Also 2nd time using turborepo and I had to add `-conditions=react-server` or I would get an error saying it should be a server component? 