### PR TITLE
Tweak: ProjectSubmission -> hide previous button on first step

### DIFF
--- a/apps/web/components/submissions/submission-form.tsx
+++ b/apps/web/components/submissions/submission-form.tsx
@@ -454,7 +454,7 @@ export default function SubmissionForm({
 
   const progress = ((currentStep + 1) / steps.length) * 100;
   return success && env.NEXT_PUBLIC_ENV === 'production' ? (
-  // return success ? (
+    // return success ? (
     <div className="flex flex-col items-center justify-center space-y-4 py-8">
       <CheckCircle className="h-16 w-16 text-green-500" />
       <h3 className="text-xl font-semibold">Submission Successful!</h3>
@@ -897,13 +897,12 @@ export default function SubmissionForm({
           )}
 
           <DialogFooter>
-            <div className="flex justify-between gap-4 pt-6 pb-20">
+            <div className="flex items-center justify-between gap-4 pt-6 pb-20">
               <Button
                 type="button"
                 variant="outline"
-                className="rounded-none"
+                className={`${currentStep === 0 ? 'hidden' : ''} rounded-none`}
                 onClick={prevStep}
-                disabled={currentStep === 0}
               >
                 <ChevronLeft className="mr-2 h-4 w-4" />
                 Previous


### PR DESCRIPTION
### This is a UI tweak.
Previously on the first step of project submission.
The previous button was visible but disabled
![Screenshot from 2025-07-09 14-48-03](https://github.com/user-attachments/assets/33cc5356-17c9-4d86-a4f6-439ac6ccd44c)


**Change** : Have set `previous` button to `disabled` if we are on the first step.
![Screenshot from 2025-07-09 14-47-14](https://github.com/user-attachments/assets/41cd89bb-90fb-41e2-8553-497e600c0029)


If this tweak is useful then do merge.