### PR TITLE
fix: sorting of projects during search

### DIFF
--- a/packages/api/src/routers/projects.ts
+++ b/packages/api/src/routers/projects.ts
@@ -149,8 +149,29 @@ export const projectsRouter = createTRPCRouter({
       const [totalCountResult] = await countQuery;
 
       const orderByClause = [];
+      if(!searchQuery){
+        orderByClause.push(desc(project.isPinned));
+      }
 
-      orderByClause.push(desc(project.isPinned));
+    if (searchQuery) {
+          const lowerSearchQuery = searchQuery.toLowerCase();
+
+          orderByClause.push(
+            desc(ilike(project.name, searchQuery))
+          );
+
+          orderByClause.push(
+            desc(ilike(project.name, `${searchQuery}%`))
+          );
+
+          orderByClause.push(
+            desc(ilike(project.name, `%${searchQuery}%`))
+          );
+
+          orderByClause.push(
+            desc(ilike(project.gitRepoUrl, `%${searchQuery}%`))
+          );
+        }
 
       switch (sortBy) {
         case 'name':


### PR DESCRIPTION
logic implementation of sorting of projects during search

Before:
<img width="1463" height="887" alt="image" src="https://github.com/user-attachments/assets/fb272fcd-c358-4823-bc68-eef2bd493d18" />
After:
<img width="1413" height="879" alt="image" src="https://github.com/user-attachments/assets/d275f0d2-7725-4e29-bce8-09470d8ecec6" />
