### PR TITLE
feat: private repos

### DIFF
--- a/apps/web/app/(admin)/admin/projects/page.tsx
+++ b/apps/web/app/(admin)/admin/projects/page.tsx
@@ -79,7 +79,7 @@ export default function AdminProjectsDashboard() {
     isLoading,
     isError,
   } = useQuery(
-    trpc.projects.getProjects.queryOptions({
+    trpc.projects.getProjectsAdmin.queryOptions({
       approvalStatus,
       page,
       pageSize,
@@ -103,7 +103,7 @@ export default function AdminProjectsDashboard() {
     ...trpc.projects.acceptProject.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: trpc.projects.getProjects.queryKey({
+        queryKey: trpc.projects.getProjectsAdmin.queryKey({
           approvalStatus,
           page,
           pageSize,
@@ -121,7 +121,7 @@ export default function AdminProjectsDashboard() {
     ...trpc.projects.rejectProject.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: trpc.projects.getProjects.queryKey({
+        queryKey: trpc.projects.getProjectsAdmin.queryKey({
           approvalStatus,
           page,
           pageSize,
@@ -139,7 +139,7 @@ export default function AdminProjectsDashboard() {
     ...trpc.projects.pinProject.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: trpc.projects.getProjects.queryKey({
+        queryKey: trpc.projects.getProjectsAdmin.queryKey({
           approvalStatus,
           page,
           pageSize,
@@ -157,7 +157,7 @@ export default function AdminProjectsDashboard() {
     ...trpc.projects.unpinProject.mutationOptions(),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: trpc.projects.getProjects.queryKey({
+        queryKey: trpc.projects.getProjectsAdmin.queryKey({
           approvalStatus,
           page,
           pageSize,
@@ -207,17 +207,13 @@ export default function AdminProjectsDashboard() {
         <p className="text-muted-foreground">Review, approve, and manage project submissions</p>
       </div>
 
-      <Tabs className="space-y-4" defaultValue={approvalStatus}>
+      <Tabs className="space-y-4" value={approvalStatus} onValueChange={(value) => { setApprovalStatus(value as typeof approvalStatus); setPage(1); }}>
         <TabsList className="bg-muted/30">
           {tabs.map((tab) => (
             <TabsTrigger
               key={tab}
               value={tab}
               className="w-28"
-              onClick={() => {
-                setApprovalStatus(tab);
-                setPage(1);
-              }}
             >
               <span className="capitalize">{tab}</span>
             </TabsTrigger>

--- a/apps/web/app/(public)/(projects)/projects/[id]/project-description.tsx
+++ b/apps/web/app/(public)/(projects)/projects/[id]/project-description.tsx
@@ -240,7 +240,15 @@ function ActionButtons({
 
   return (
     <div className={className}>
-      {isOwner && <LaunchProjectDialog projectId={project.id} projectName={project.name} />}
+      {isOwner && (
+        <LaunchProjectDialog
+          projectId={project.id}
+          projectName={project.name}
+          isRepoPrivate={project.isRepoPrivate || repo?.isPrivate}
+          gitRepoUrl={project.gitRepoUrl || undefined}
+          gitHost={project.gitHost || undefined}
+        />
+      )}
       {repoUrl && (
         <Link
           href={repoUrl}

--- a/apps/web/components/project/launch-project-dialog.tsx
+++ b/apps/web/components/project/launch-project-dialog.tsx
@@ -23,7 +23,7 @@ import { Textarea } from '@workspace/ui/components/textarea';
 import { Button } from '@workspace/ui/components/button';
 import { Input } from '@workspace/ui/components/input';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Rocket, Loader2 } from 'lucide-react';
+import { Rocket, Loader2, RefreshCw, ExternalLink, AlertCircle } from 'lucide-react';
 import { useTRPC } from '@/hooks/use-trpc';
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
@@ -43,10 +43,20 @@ type LaunchFormData = z.infer<typeof launchSchema>;
 interface LaunchProjectDialogProps {
   projectId: string;
   projectName: string;
+  isRepoPrivate?: boolean;
+  gitRepoUrl?: string;
+  gitHost?: string;
 }
 
-export function LaunchProjectDialog({ projectId, projectName }: LaunchProjectDialogProps) {
+export function LaunchProjectDialog({
+  projectId,
+  projectName,
+  isRepoPrivate,
+  gitRepoUrl,
+  gitHost
+}: LaunchProjectDialogProps) {
   const [open, setOpen] = useState(false);
+  const [privateRepoDialogOpen, setPrivateRepoDialogOpen] = useState(false);
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
@@ -58,6 +68,39 @@ export function LaunchProjectDialog({ projectId, projectName }: LaunchProjectDia
     },
   });
 
+  const refreshRepoStatusMutation = useMutation(
+    trpc.projects.refreshRepoStatus.mutationOptions({
+      onSuccess: (data) => {
+                // Always invalidate queries to ensure fresh data
+        queryClient.invalidateQueries({
+          queryKey: trpc.projects.getProject.queryKey({ id: projectId }),
+        });
+
+        // Also invalidate repository data cache
+        queryClient.invalidateQueries({
+          predicate: (query) => query.queryKey[0] === 'repository',
+        });
+
+        if (data.statusChanged && !data.isNowPrivate) {
+          toast.success('Repository is now public! You can launch your project.');
+          setPrivateRepoDialogOpen(false);
+          // Force a page refresh to ensure UI updates with new data
+          setTimeout(() => window.location.reload(), 1000);
+        } else if (data.statusChanged && data.isNowPrivate) {
+          toast.info('Repository is now private.');
+        } else if (!data.statusChanged && data.isNowPrivate) {
+          toast.info('Repository is still private. Please make it public to launch.');
+        } else if (!data.statusChanged && !data.isNowPrivate) {
+          toast.success('Repository is already public! You can launch your project.');
+          setPrivateRepoDialogOpen(false);
+        }
+      },
+      onError: (error) => {
+        toast.error(error.message || 'Failed to refresh repository status');
+      },
+    }),
+  );
+
   const launchMutation = useMutation(
     trpc.launches.launchProject.mutationOptions({
       onSuccess: () => {
@@ -68,7 +111,7 @@ export function LaunchProjectDialog({ projectId, projectName }: LaunchProjectDia
           queryKey: trpc.launches.getTodayLaunches.queryKey({ limit: 50 }),
         });
       },
-      onError: (error) => {
+      onError: (error: any) => {
         toast.error(error.message || 'Failed to launch project');
       },
     }),
@@ -81,83 +124,225 @@ export function LaunchProjectDialog({ projectId, projectName }: LaunchProjectDia
     });
   };
 
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button className="gap-2 rounded-none" size="sm">
-          <Rocket className="h-4 w-4" />
-          Launch Project
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-[600px]">
+      const getRepoSettingsUrl = () => {
+    if (!gitRepoUrl || !gitHost) return '';
+
+    try {
+      // Handle different URL formats
+      let repoPath = '';
+
+      if (gitRepoUrl.includes('github.com') || gitRepoUrl.includes('gitlab.com')) {
+        const url = new URL(gitRepoUrl);
+        repoPath = url.pathname;
+      } else {
+        // Handle formats like "owner/repo" or "owner/repo.git"
+        repoPath = `/${gitRepoUrl}`;
+      }
+
+      const pathParts = repoPath.split('/').filter(Boolean);
+
+      if (pathParts.length >= 2) {
+        const owner = pathParts[0];
+        const repo = pathParts[1]?.replace(/\.git$/, '') || '';
+
+        if (gitHost === 'github') {
+          return `https://github.com/${owner}/${repo}/settings`;
+        } else if (gitHost === 'gitlab') {
+          return `https://gitlab.com/${owner}/${repo}/-/settings/general`;
+        }
+      }
+    } catch (e) {
+      console.error('Failed to parse repository URL:', e);
+
+      // Fallback: try to extract owner/repo from the URL string
+      const match = gitRepoUrl.match(/(?:github\.com|gitlab\.com)[/:]([^/]+)\/([^/]+?)(?:\.git)?(?:\/|$)/);
+      if (match) {
+        const [, owner, repo] = match;
+        if (gitHost === 'github') {
+          return `https://github.com/${owner}/${repo}/settings`;
+        } else if (gitHost === 'gitlab') {
+          return `https://gitlab.com/${owner}/${repo}/-/settings/general`;
+        }
+      }
+    }
+
+    // Final fallback - return the original repo URL
+    return gitRepoUrl.replace(/\.git$/, '');
+  };
+
+  const handleRefreshStatus = () => {
+    refreshRepoStatusMutation.mutate({ projectId });
+  };
+
+  // Private Repository Dialog
+  const PrivateRepoDialog = () => (
+    <Dialog open={privateRepoDialogOpen} onOpenChange={setPrivateRepoDialogOpen}>
+      <DialogContent className="sm:max-w-[500px] rounded-none">
         <DialogHeader>
-          <DialogTitle>Launch {projectName}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-yellow-500" />
+            Repository is Private
+          </DialogTitle>
           <DialogDescription>
-            Launch your project to get it featured on the launches page. Make sure to craft a
-            compelling tagline that describes what makes your project unique.
+            Your repository needs to be public to launch your project on our platform.
           </DialogDescription>
         </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            <FormField
-              control={form.control}
-              name="tagline"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Tagline</FormLabel>
-                  <FormControl>
-                    <Input placeholder="A short, catchy description of your project" {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    This will be the first thing people see about your project
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
 
-            <FormField
-              control={form.control}
-              name="detailedDescription"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Detailed Description (Optional)</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Tell us more about your project, what problem it solves, key features, etc."
-                      className="min-h-[120px]"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Provide more context about your project for interested users
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+        <div className="space-y-4">
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-none p-4">
+            <h4 className="font-medium text-yellow-800 dark:text-yellow-200 mb-2">
+              Why does my repository need to be public?
+            </h4>
+            <ul className="text-sm text-yellow-700 dark:text-yellow-300 space-y-1">
+              <li>• Community members can discover and contribute to your project</li>
+              <li>• Ensures transparency and builds trust with users</li>
+              <li>• Allows proper validation of your project's authenticity</li>
+            </ul>
+          </div>
 
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setOpen(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={launchMutation.isPending}>
-                {launchMutation.isPending ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Launching...
-                  </>
-                ) : (
-                  <>
-                    <Rocket className="mr-2 h-4 w-4" />
-                    Launch Project
-                  </>
-                )}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+          <div className="space-y-2">
+            <h4 className="font-medium">How to make your repository public:</h4>
+            <ol className="text-sm text-muted-foreground space-y-1">
+              <li>1. Go to your repository settings</li>
+              <li>2. Scroll down to the "Danger Zone" section</li>
+              <li>3. Click "Change visibility" and select "Public"</li>
+              <li>4. Come back here and click "Check Status" to retry</li>
+            </ol>
+          </div>
+        </div>
+
+        <DialogFooter className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setPrivateRepoDialogOpen(false)}
+            className="rounded-none"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleRefreshStatus}
+            disabled={refreshRepoStatusMutation.isPending}
+            className="rounded-none"
+          >
+            {refreshRepoStatusMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin rounded-none" />
+                Checking...
+              </>
+            ) : (
+              <>
+                <RefreshCw className="mr-2 h-4 w-4 rounded-none" />
+                Check Status
+              </>
+            )}
+          </Button>
+          <Button
+            onClick={() => window.open(getRepoSettingsUrl(), '_blank')}
+            className="gap-2 rounded-none"
+          >
+            <ExternalLink className="h-4 w-4" />
+            Repository Settings
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+
+  return (
+    <>
+      {isRepoPrivate ? (
+        <>
+          <Button
+            className="gap-2 rounded-none"
+            size="sm"
+            onClick={() => setPrivateRepoDialogOpen(true)}
+            variant="outline"
+          >
+            <Rocket className="h-4 w-4" />
+            Launch Project
+          </Button>
+          <PrivateRepoDialog />
+        </>
+      ) : (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button className="gap-2 rounded-none" size="sm">
+              <Rocket className="h-4 w-4" />
+              Launch Project
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-[600px] rounded-none">
+            <DialogHeader>
+              <DialogTitle>Launch {projectName}</DialogTitle>
+              <DialogDescription>
+                Launch your project to get it featured on the launches page. Make sure to craft a
+                compelling tagline that describes what makes your project unique.
+              </DialogDescription>
+            </DialogHeader>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="tagline"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tagline</FormLabel>
+                      <FormControl>
+                        <Input placeholder="A short, catchy description of your project" {...field} className="rounded-none" />
+                      </FormControl>
+                      <FormDescription>
+                        This will be the first thing people see about your project
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="detailedDescription"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Detailed Description (Optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Tell us more about your project, what problem it solves, key features, etc."
+                          className="min-h-[120px] rounded-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Provide more context about your project for interested users
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setOpen(false)} className="rounded-none">
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={launchMutation.isPending} className="rounded-none">
+                    {launchMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin rounded-none" />
+                        Launching...
+                      </>
+                    ) : (
+                      <>
+                        <Rocket className="mr-2 h-4 w-4 rounded-none" />
+                        Launch Project
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   );
 }

--- a/apps/web/components/submissions/early-submission-dialog.tsx
+++ b/apps/web/components/submissions/early-submission-dialog.tsx
@@ -11,10 +11,19 @@ import {
 import { Button } from '@workspace/ui/components/button';
 import SubmissionForm from './submission-form';
 import { ArrowRight } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 
 export default function EarlySubmissionDialog() {
+  const [open, setOpen] = useState(false);
+
+  const handleSuccess = () => {
+    toast.success('Project submitted successfully! We\'ll review it and get back to you soon.');
+    setOpen(false);
+  };
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" className="flex items-center gap-2 rounded-none">
           <span>Early Submission</span>
@@ -26,7 +35,7 @@ export default function EarlySubmissionDialog() {
           <DialogTitle>Early Submission</DialogTitle>
           <DialogDescription>Submit your open source project for early access.</DialogDescription>
         </DialogHeader>
-        <SubmissionForm />
+        <SubmissionForm earlySubmission={true} onSuccess={handleSuccess} />
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/components/submissions/submission-dialog.tsx
+++ b/apps/web/components/submissions/submission-dialog.tsx
@@ -12,10 +12,19 @@ import { track as trackVercel } from '@vercel/analytics/react';
 import { Button } from '@workspace/ui/components/button';
 import { track as trackDatabuddy } from '@databuddy/sdk';
 import SubmissionForm from './submission-form';
+import { useState } from 'react';
+import { toast } from 'sonner';
 
 export default function SubmissionDialog() {
+  const [open, setOpen] = useState(false);
+
+  const handleSuccess = () => {
+    toast.success('Project submitted successfully! We\'ll review it and get back to you soon.');
+    setOpen(false);
+  };
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           onClick={() => {
@@ -33,7 +42,7 @@ export default function SubmissionDialog() {
           <DialogTitle>Submit Project</DialogTitle>
           <DialogDescription>Submit an open source project.</DialogDescription>
         </DialogHeader>
-        <SubmissionForm />
+        <SubmissionForm onSuccess={handleSuccess} />
       </DialogContent>
     </Dialog>
   );

--- a/packages/api/src/driver/github.ts
+++ b/packages/api/src/driver/github.ts
@@ -55,20 +55,13 @@ export class GithubManager implements GitManager {
       async () => {
         const { data } = await this.octokit.rest.repos.get({ owner, repo });
 
-        if (data.private) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message:
-              'Private repositories cannot be submitted. Please make your repository public first.',
-          });
-        }
-
         return {
           ...data,
           id: data.id,
           name: data.name,
           description: data.description ?? undefined,
           url: data.html_url,
+          isPrivate: data.private,
         };
       },
       { ttl: 5 * 60 },

--- a/packages/api/src/driver/gitlab.ts
+++ b/packages/api/src/driver/gitlab.ts
@@ -56,13 +56,7 @@ export class GitlabManager implements GitManager {
         try {
           const projectData = await this.gitlab.Projects.show(identifier);
 
-          if (projectData.visibility === 'private' || projectData.visibility === 'internal') {
-            throw new TRPCError({
-              code: 'FORBIDDEN',
-              message:
-                'Private or internal repositories cannot be submitted. Please make your repository public first.',
-            });
-          }
+          const isPrivate = projectData.visibility === 'private' || projectData.visibility === 'internal';
 
           return {
             ...projectData,
@@ -70,6 +64,7 @@ export class GitlabManager implements GitManager {
             name: projectData.name,
             description: projectData.description ?? undefined,
             url: projectData.web_url as string,
+            isPrivate,
           };
         } catch (error) {
           if (error instanceof TRPCError) {

--- a/packages/api/src/driver/types.ts
+++ b/packages/api/src/driver/types.ts
@@ -45,6 +45,7 @@ export interface ProjectWithRelations {
   isLookingForInvestors: boolean;
   isHiring: boolean;
   isPublic: boolean;
+  isRepoPrivate: boolean;
   acquiredBy: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -75,6 +76,7 @@ export interface RepoData {
   name: string;
   description?: string;
   url: string;
+  isPrivate?: boolean;
   [key: string]: any;
 }
 

--- a/packages/api/src/routers/early-submissions.ts
+++ b/packages/api/src/routers/early-submissions.ts
@@ -46,21 +46,16 @@ export const earlySubmissionRouter = createTRPCRouter({
       }
     }
 
-    // Validate that the repository is not private
+    // Validate repository and get privacy status
+    let isRepoPrivate = false;
     if (input.gitHost && input.gitRepoUrl) {
       try {
         const driver = await getActiveDriver(input.gitHost as 'github' | 'gitlab', ctx);
-        await driver.getRepo(input.gitRepoUrl);
+        const repoData = await driver.getRepo(input.gitRepoUrl);
+        isRepoPrivate = repoData.isPrivate || false;
       } catch (error) {
-        if (
-          error instanceof TRPCError &&
-          error.code === 'FORBIDDEN' &&
-          (error.message.includes('Private repositories cannot be submitted') ||
-            error.message.includes('Private or internal repositories cannot be submitted'))
-        ) {
-          throw error;
-        }
-        // If it's another error, continue with the flow
+        // If there's an error fetching the repo, we'll continue with the flow
+        // This allows for cases where the repo might be temporarily unavailable
       }
     }
 
@@ -74,11 +69,23 @@ export const earlySubmissionRouter = createTRPCRouter({
       const [newProject] = await tx
         .insert(project)
         .values({
-          ...input,
+          logoUrl: input.logoUrl,
+          gitRepoUrl: input.gitRepoUrl,
+          gitHost: input.gitHost,
+          name: input.name,
+          description: input.description,
+          socialLinks: input.socialLinks,
+          isLookingForContributors: input.isLookingForContributors,
+          isLookingForInvestors: input.isLookingForInvestors,
+          isHiring: input.isHiring,
+          isPublic: input.isPublic,
+          hasBeenAcquired: input.hasBeenAcquired,
+          acquiredBy: input.acquiredBy,
           ownerId: null,
           approvalStatus: APPROVAL_STATUS.PENDING,
           statusId,
           typeId,
+          isRepoPrivate,
         })
         .onConflictDoNothing({ target: project.gitRepoUrl })
         .returning();

--- a/packages/api/src/routers/launches.ts
+++ b/packages/api/src/routers/launches.ts
@@ -148,6 +148,7 @@ export const launchesRouter = createTRPCRouter({
         .where(
           and(
             eq(project.approvalStatus, 'approved'),
+            eq(project.isRepoPrivate, false),
             gte(projectLaunch.launchDate, startOfToday),
             lt(projectLaunch.launchDate, endOfToday),
           ),
@@ -271,6 +272,7 @@ export const launchesRouter = createTRPCRouter({
         .where(
           and(
             eq(project.approvalStatus, 'approved'),
+            eq(project.isRepoPrivate, false),
             gte(projectLaunch.launchDate, startOfYesterday),
             lt(projectLaunch.launchDate, endOfYesterday),
           ),
@@ -387,7 +389,7 @@ export const launchesRouter = createTRPCRouter({
         .leftJoin(user, eq(project.ownerId, user.id))
         .leftJoin(projectVote, eq(projectVote.projectId, project.id))
         .leftJoin(projectComment, eq(projectComment.projectId, project.id))
-        .where(and(eq(project.approvalStatus, 'approved')))
+        .where(and(eq(project.approvalStatus, 'approved'), eq(project.isRepoPrivate, false)))
         .groupBy(
           project.id,
           projectLaunch.id,
@@ -592,6 +594,13 @@ export const launchesRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'You can only launch your own projects',
+        });
+      }
+
+      if (foundProject.isRepoPrivate) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You cannot launch a project with a private repository. Please make your repository public first.',
         });
       }
 

--- a/packages/db/drizzle/0016_groovy_kitty_pryde.sql
+++ b/packages/db/drizzle/0016_groovy_kitty_pryde.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "project" ADD COLUMN "is_repo_private" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0016_snapshot.json
+++ b/packages/db/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1918 @@
+{
+  "id": "12af398c-49a3-42fc-a780-dfe12b23108d",
+  "prevId": "cbb41484-c973-48de-8139-bc4eca9186a2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitor": {
+      "name": "competitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo_url": {
+          "name": "git_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_host": {
+          "name": "git_host",
+          "type": "git_host",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitor_tag_relations": {
+      "name": "competitor_tag_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competitor_id": {
+          "name": "competitor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitor_tag_relations_competitor_id_idx": {
+          "name": "competitor_tag_relations_competitor_id_idx",
+          "columns": [
+            {
+              "expression": "competitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitor_tag_relations_tag_id_idx": {
+          "name": "competitor_tag_relations_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_competitor_tag": {
+          "name": "unique_competitor_tag",
+          "columns": [
+            {
+              "expression": "competitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitor_tag_relations_competitor_id_competitor_id_fk": {
+          "name": "competitor_tag_relations_competitor_id_competitor_id_fk",
+          "tableFrom": "competitor_tag_relations",
+          "tableTo": "competitor",
+          "columnsFrom": [
+            "competitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competitor_tag_relations_tag_id_category_tags_id_fk": {
+          "name": "competitor_tag_relations_tag_id_category_tags_id_fk",
+          "tableFrom": "competitor_tag_relations",
+          "tableTo": "category_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo_url": {
+          "name": "git_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_host": {
+          "name": "git_host",
+          "type": "git_host",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "project_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_looking_for_contributors": {
+          "name": "is_looking_for_contributors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_looking_for_investors": {
+          "name": "is_looking_for_investors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_hiring": {
+          "name": "is_hiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_been_acquired": {
+          "name": "has_been_acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_repo_private": {
+          "name": "is_repo_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acquired_by": {
+          "name": "acquired_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_status_id_idx": {
+          "name": "project_status_id_idx",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_type_id_idx": {
+          "name": "project_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_owner_id_user_id_fk": {
+          "name": "project_owner_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_status_id_category_project_statuses_id_fk": {
+          "name": "project_status_id_category_project_statuses_id_fk",
+          "tableFrom": "project",
+          "tableTo": "category_project_statuses",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_type_id_category_project_types_id_fk": {
+          "name": "project_type_id_category_project_types_id_fk",
+          "tableFrom": "project",
+          "tableTo": "category_project_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_acquired_by_competitor_id_fk": {
+          "name": "project_acquired_by_competitor_id_fk",
+          "tableFrom": "project",
+          "tableTo": "competitor",
+          "columnsFrom": [
+            "acquired_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_git_repo_url_unique": {
+          "name": "project_git_repo_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "git_repo_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_tag_relations": {
+      "name": "project_tag_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_tag_relations_project_id_idx": {
+          "name": "project_tag_relations_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_tag_relations_tag_id_idx": {
+          "name": "project_tag_relations_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_project_tag": {
+          "name": "unique_project_tag",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_tag_relations_project_id_project_id_fk": {
+          "name": "project_tag_relations_project_id_project_id_fk",
+          "tableFrom": "project_tag_relations",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tag_relations_tag_id_category_tags_id_fk": {
+          "name": "project_tag_relations_tag_id_category_tags_id_fk",
+          "tableFrom": "project_tag_relations",
+          "tableTo": "category_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_competitors": {
+      "name": "project_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternative_competitor_type": {
+          "name": "alternative_competitor_type",
+          "type": "alternative_competitor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternative_project_id": {
+          "name": "alternative_project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_competitor_id": {
+          "name": "alternative_competitor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_competitors_project_id_idx": {
+          "name": "project_competitors_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_competitors_alt_project_id_idx": {
+          "name": "project_competitors_alt_project_id_idx",
+          "columns": [
+            {
+              "expression": "alternative_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_competitors_alt_competitor_id_idx": {
+          "name": "project_competitors_alt_competitor_id_idx",
+          "columns": [
+            {
+              "expression": "alternative_competitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_project_id_fk": {
+          "name": "project_competitors_project_id_project_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_competitors_alternative_project_id_project_id_fk": {
+          "name": "project_competitors_alternative_project_id_project_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "project",
+          "columnsFrom": [
+            "alternative_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_competitors_alternative_competitor_id_competitor_id_fk": {
+          "name": "project_competitors_alternative_competitor_id_competitor_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "competitor",
+          "columnsFrom": [
+            "alternative_competitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_claim": {
+      "name": "project_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_method": {
+          "name": "verification_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_details": {
+          "name": "verification_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_reason": {
+          "name": "error_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_claim_project_id_project_id_fk": {
+          "name": "project_claim_project_id_project_id_fk",
+          "tableFrom": "project_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_claim_user_id_user_id_fk": {
+          "name": "project_claim_user_id_user_id_fk",
+          "tableFrom": "project_claim",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_project_statuses": {
+      "name": "category_project_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category_project_statuses_name_unique": {
+          "name": "category_project_statuses_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_project_types": {
+      "name": "category_project_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category_project_types_name_unique": {
+          "name": "category_project_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_tags": {
+      "name": "category_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category_tags_name_unique": {
+          "name": "category_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_launch": {
+      "name": "project_launch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detailed_description": {
+          "name": "detailed_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_date": {
+          "name": "launch_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_launch_project_id_idx": {
+          "name": "project_launch_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_launch_launch_date_idx": {
+          "name": "project_launch_launch_date_idx",
+          "columns": [
+            {
+              "expression": "launch_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_launch_project_id_project_id_fk": {
+          "name": "project_launch_project_id_project_id_fk",
+          "tableFrom": "project_launch",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_launch_project_id_unique": {
+          "name": "project_launch_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_vote": {
+      "name": "project_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_vote_project_id_idx": {
+          "name": "project_vote_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_vote_user_id_idx": {
+          "name": "project_vote_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_vote_project_id_project_id_fk": {
+          "name": "project_vote_project_id_project_id_fk",
+          "tableFrom": "project_vote",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_vote_user_id_user_id_fk": {
+          "name": "project_vote_user_id_user_id_fk",
+          "tableFrom": "project_vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_vote_project_id_user_id_unique": {
+          "name": "project_vote_project_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_comment": {
+      "name": "project_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_comment_project_id_idx": {
+          "name": "project_comment_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_comment_user_id_idx": {
+          "name": "project_comment_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_comment_parent_id_idx": {
+          "name": "project_comment_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_comment_project_id_project_id_fk": {
+          "name": "project_comment_project_id_project_id_fk",
+          "tableFrom": "project_comment",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_comment_user_id_user_id_fk": {
+          "name": "project_comment_user_id_user_id_fk",
+          "tableFrom": "project_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_comment_parent_id_project_comment_id_fk": {
+          "name": "project_comment_parent_id_project_comment_id_fk",
+          "tableFrom": "project_comment",
+          "tableTo": "project_comment",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_report": {
+      "name": "project_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_report_project_id_idx": {
+          "name": "project_report_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_report_user_id_idx": {
+          "name": "project_report_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_report_project_id_project_id_fk": {
+          "name": "project_report_project_id_project_id_fk",
+          "tableFrom": "project_report",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_report_user_id_user_id_fk": {
+          "name": "project_report_user_id_user_id_fk",
+          "tableFrom": "project_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_report_project_id_user_id_unique": {
+          "name": "project_report_project_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.acquisition_type": {
+      "name": "acquisition_type",
+      "schema": "public",
+      "values": [
+        "ipo",
+        "acquisition",
+        "other"
+      ]
+    },
+    "public.project_approval_status": {
+      "name": "project_approval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.alternative_competitor_type": {
+      "name": "alternative_competitor_type",
+      "schema": "public",
+      "values": [
+        "project",
+        "competitor"
+      ]
+    },
+    "public.git_host": {
+      "name": "git_host",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab"
+      ]
+    },
+    "public.project_provider": {
+      "name": "project_provider",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1751784724679,
       "tag": "0015_supreme_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1752620088726,
+      "tag": "0016_groovy_kitty_pryde",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/projects.ts
+++ b/packages/db/src/schema/projects.ts
@@ -47,6 +47,7 @@ export const project = pgTable(
     isPublic: boolean('is_public').notNull().default(false),
     hasBeenAcquired: boolean('has_been_acquired').notNull().default(false),
     isPinned: boolean('is_pinned').notNull().default(false),
+    isRepoPrivate: boolean('is_repo_private').notNull().default(false),
     acquiredBy: uuid('acquired_by').references(() => competitor.id, { onDelete: 'set null' }),
 
     deletedAt: timestamp('deleted_at', { mode: 'date' }),

--- a/packages/ui/src/components/app-sidebar.tsx
+++ b/packages/ui/src/components/app-sidebar.tsx
@@ -9,7 +9,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarRail,
 } from '@workspace/ui/components/sidebar';
 import { FolderOpen, LayoutDashboard, ListChecks, Tags, Users } from 'lucide-react';
 import { NavUser } from '@workspace/ui/components/nav-user';


### PR DESCRIPTION
## private repo support is here

yeah, you can now submit **private repos** (GitHub & GitLab). 

---

### what actually changed

#### 1. automatic privacy detection

we check if the repo is private when you submit it :

* new `isRepoPrivate` field in the DB
* works for both GitHub + GitLab

<img width="535" height="545" alt="image" src="https://github.com/user-attachments/assets/86964c17-2f8f-4586-87c5-e7a87cb028c7" />

---

#### 1. how they work:

* private projects **don’t show up** in public listings, feeds, launch pages, etc.
* only **you** can see them on your profile
* **admins** can still see all projects (obviously)

<img width="1121" height="466" alt="image" src="https://github.com/user-attachments/assets/44794719-b7fb-41f9-9939-1c1f07640d7e" />
<img width="1263" height="714" alt="image" src="https://github.com/user-attachments/assets/3f56d05f-c146-4eb7-b7a5-100d04de0f7a" />

---

#### launching private repos is blocked

if your repo is private, you’ll get a message when you try to launch it.

* explains why you can’t launch
* includes a **"check status"** button to re-check the repo
* includes a link to your repo’s visibility settings

<img width="571" height="541" alt="image" src="https://github.com/user-attachments/assets/659b39eb-1bcd-4f40-8ab8-f2d397107829" />

---

### tl;dr

*  you can now make projects w/ private repos
* they stay hidden unless you make them public
* launch flow won’t let you push private stuff to the feed
* easy to update privacy if/when you’re ready

---

let me know if anything’s broken.
