### PR TITLE
Responsive numbers for smaller screens in Profile page

### DIFF
--- a/apps/web/components/user/profile.tsx
+++ b/apps/web/components/user/profile.tsx
@@ -20,6 +20,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@workspace/ui/components/tabs';
 import { Avatar, AvatarFallback, AvatarImage } from '@workspace/ui/components/avatar';
 import ProjectCard from '@/app/(public)/(projects)/projects/project-card';
+import ResponsiveNumber from '@/components/user/responsive-numbers';
 import { Card, CardContent } from '@workspace/ui/components/card';
 import { Skeleton } from '@workspace/ui/components/skeleton';
 import { useQueries, useQuery } from '@tanstack/react-query';
@@ -201,19 +202,21 @@ export default function ProfilePage({ id }: { id: string }) {
                           <div className="text-xs text-neutral-400">Projects</div>
                         </div>
                         <div>
-                          <div className="text-2xl font-bold">
-                            {(
+                          <ResponsiveNumber
+                            value={
                               projectsWithGithubData?.reduce((sum, p) => sum + p.stars, 0) || 0
-                            ).toLocaleString()}
-                          </div>
+                            }
+                            className="text-2xl font-bold"
+                          />
                           <div className="text-xs text-neutral-400">Total Stars</div>
                         </div>
                         <div>
-                          <div className="text-2xl font-bold">
-                            {(
+                          <ResponsiveNumber
+                            value={
                               projectsWithGithubData?.reduce((sum, p) => sum + p.forks, 0) || 0
-                            ).toLocaleString()}
-                          </div>
+                            }
+                            className="text-2xl font-bold"
+                          />
                           <div className="text-xs text-neutral-400">Total Forks</div>
                         </div>
                       </div>

--- a/apps/web/components/user/responsive-numbers.tsx
+++ b/apps/web/components/user/responsive-numbers.tsx
@@ -1,0 +1,21 @@
+const ResponsiveNumber = ({ value, className }: { value: number; className: string }) => {
+  const formatNumber = (num: number) => {
+    if (num >= 1000000000) {
+      return (num / 1000000000).toFixed(1).replace('.0', '') + 'B';
+    } else if (num >= 1000000) {
+      return (num / 1000000).toFixed(1).replace('.0', '') + 'M';
+    } else if (num >= 1000) {
+      return (num / 1000).toFixed(1).replace('.0', '') + 'K';
+    }
+    return num.toLocaleString();
+  };
+
+  return (
+    <span className={className} title={value.toLocaleString()}>
+      <span className="hidden sm:inline">{value.toLocaleString()}</span>
+      <span className="sm:hidden">{formatNumber(value)}</span>
+    </span>
+  );
+};
+
+export default ResponsiveNumber;


### PR DESCRIPTION
## Description

In smaller screens the `Total Stars` and `Total Fork` numbers were overlapping each other. This PR adds a ResponsiveNumber component which renders `Abbreviated Numbers` for smaller screens.

> [!NOTE]
> The Abbreviated numbers are round-off, this can be enhanced to show 2-decimal values also. 



## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ⚡ Performance improvement
- [ ] Other (please describe)

## Testing

- [x] I have tested my changes locally

## Checklist

- [x] My code follows the project style
- [x] I've updated relevant documentation

## Screenshots (if applicable)

Before:

 <img width="1352" height="210" alt="Screenshot from 2025-07-17 12-39-30" src="https://github.com/user-attachments/assets/0fd05466-a567-492c-9759-aa94d6f5e117" />

After : 

<img width="714" height="224" alt="Screenshot from 2025-07-17 13-20-02" src="https://github.com/user-attachments/assets/ffdb616c-156a-46b0-a0b8-373051dd3690" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new responsive number display for total stars and forks on user profiles, providing compact formatting (e.g., "1.2K", "3.4M") on smaller screens and full numbers on larger screens, with tooltips for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->