### PR TITLE
Emoji Fix in README view of projects

### DIFF
--- a/apps/web/app/(public)/(projects)/projects/[id]/markdown-content.tsx
+++ b/apps/web/app/(public)/(projects)/projects/[id]/markdown-content.tsx
@@ -3,6 +3,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
 import Link from '@workspace/ui/components/link';
+import {Base64} from 'js-base64'
 
 interface MarkdownContentProps {
   content: string;
@@ -11,7 +12,7 @@ interface MarkdownContentProps {
 
 function decodeBase64Content(content: string): string {
   try {
-    return atob(content);
+    return Base64.decode(content);
   } catch (error) {
     console.error('Failed to decode base64 content:', error);
     return 'Error: Unable to decode content. The file may be corrupted or not properly encoded.';
@@ -40,7 +41,7 @@ const markdownComponents: Components = {
     </h4>
   ),
   p: ({ children }) => (
-    <p className="text-neutral-300 mb-4 leading-relaxed">
+    <p className="text-neutral-300  mb-4 inline leading-relaxed">
       {children}
     </p>
   ),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "better-auth": "^1.2.10",
     "date-fns": "^4.1.0",
     "drizzle-zod": "^0.8.2",
+    "js-base64": "^3.7.7",
     "lucide-react": "^0.518.0",
     "motion": "^12.18.1",
     "next": "^15.3.4",

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "better-auth": "^1.2.10",
         "date-fns": "^4.1.0",
         "drizzle-zod": "^0.8.2",
+        "js-base64": "^3.7.7",
         "lucide-react": "^0.518.0",
         "motion": "^12.18.1",
         "next": "^15.3.4",
@@ -1223,6 +1224,8 @@
     "jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
 
     "jose": ["jose@6.0.12", "", {}, "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ=="],
+
+    "js-base64": ["js-base64@3.7.7", "", {}, "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 


### PR DESCRIPTION
## Description

Fixes #90 
Introduce package `js-base64` for better decoding of content as `atob()` malformed the content of readme.
Also added `inline` to `<p>` so that  it does not move to next line after the `::marker`

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ⚡ Performance improvement
- [ ] Other (please describe)

## Testing

- [x] I have tested my changes locally

## Checklist

- [x] My code follows the project style
- [ ] I've updated relevant documentation

## Screenshots (if applicable)

| oss.now | github |
|---------|--------|
| <img width="1367" height="1554" alt="Screenshot from 2025-07-17 18-31-35" src="https://github.com/user-attachments/assets/616ca3c8-7844-42e6-ac2c-b8636ed41015" /> | <img width="1367" height="1462" alt="Screenshot from 2025-07-17 18-27-44" src="https://github.com/user-attachments/assets/57ec2537-d4ca-4f45-acbc-c9266a047ac5" /> |

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated paragraph elements in markdown content to include an additional inline display style.

* **Chores**
  * Added a new dependency to improve base64 decoding reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->