### PR TITLE
fix: preserve redirect URL after login from protected action

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,11 @@
+'use client';
 import { LoginForm } from '@/components/auth/login-form';
 
+import { useSearchParams } from 'next/navigation';
 export default function Page() {
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') ?? '/';
+  console.log('redirect url');
   return (
     <div className="relative mx-auto h-[calc(100vh-66px)] max-w-[1080px]">
       <div className="absolute top-0 right-0 bottom-0 z-0 flex aspect-square w-full items-center justify-end bg-transparent mix-blend-screen md:w-[1000px]">
@@ -13,7 +18,7 @@ export default function Page() {
       </div>
       <div className="flex h-full flex-col items-center justify-center gap-8">
         {/* <Icons.logo className="mb-10 size-20" /> */}
-        <LoginForm className="min-w-sm" />
+        <LoginForm className="min-w-sm" redirectUrl={redirect} />
       </div>
     </div>
   );

--- a/apps/web/app/(public)/launches/[id]/page.tsx
+++ b/apps/web/app/(public)/launches/[id]/page.tsx
@@ -1,23 +1,34 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
 import LaunchComments from './components/launch-comments';
 import LaunchSidebar from './components/launch-sidebar';
 import LaunchHeader from './components/launch-header';
-import { useQuery } from '@tanstack/react-query';
-import { use, useEffect, useState } from 'react';
+
+import { authClient } from '@workspace/auth/client';
 import { useTRPC } from '@/hooks/use-trpc';
 
-export default function LaunchDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const resolvedParams = use(params);
-  const projectId = resolvedParams.id;
+export default function LaunchDetailPage({ params }: { params: { id: string } }) {
+  const projectId = params.id;
   const trpc = useTRPC();
+  const router = useRouter();
+  const { data: session, isPending: sessionStatus } = authClient.useSession();
+
   const [showShadow, setShowShadow] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
-      setShowShadow(window.scrollY > 10);
-    };
+    if (sessionStatus) return;
+    if (!session?.user) {
+      const redirectPath = encodeURIComponent(`/launches/${projectId}`);
+      router.push(`/login?redirect=${redirectPath}`);
+    }
+  }, [session, sessionStatus, projectId, router]);
 
+  useEffect(() => {
+    const handleScroll = () => setShowShadow(window.scrollY > 10);
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
@@ -25,35 +36,33 @@ export default function LaunchDetailPage({ params }: { params: Promise<{ id: str
   const { data: launch, isLoading: launchLoading } = useQuery(
     trpc.launches.getLaunchByProjectId.queryOptions({ projectId }),
   );
-
   const { data: project } = useQuery(trpc.projects.getProject.queryOptions({ id: projectId }));
-
   const { data: comments, isLoading: commentsLoading } = useQuery(
     trpc.launches.getComments.queryOptions({ projectId }),
   );
 
-  if (launchLoading || !launch) {
+  if (sessionStatus || launchLoading || !launch) {
     return (
       <div className="flex h-screen items-center justify-center">
-        <div className="py-12 text-center">
-          <p className="text-neutral-400">Loading launch details...</p>
-        </div>
+        <p className="text-neutral-400">Loading launch details...</p>
       </div>
     );
   }
 
   return (
     <div className="mt-6 px-6 md:mt-8">
+      {/* Top shadow on scroll */}
       <div
         className={`pointer-events-none fixed top-[calc(32px+65px)] z-10 h-10 w-full bg-gradient-to-b from-[#101010] to-transparent transition-all duration-300 ${
           showShadow ? 'opacity-100' : 'opacity-0'
         }`}
       />
       <div className="fixed top-0 right-0 left-0 z-10 h-[32px] bg-[#101010]" />
+
       <div className="mx-auto max-w-[1080px] py-4">
         <div className="grid gap-4 lg:grid-cols-3">
           <div className="flex min-w-0 flex-col gap-4 overflow-hidden lg:col-span-2">
-            {/* Main Launch Content */}
+            {/* Header */}
             <LaunchHeader launch={launch} project={project} projectId={projectId} />
 
             {/* About Section */}
@@ -66,7 +75,7 @@ export default function LaunchDetailPage({ params }: { params: Promise<{ id: str
               </div>
             )}
 
-            {/* Comments Section */}
+            {/* Comments */}
             <LaunchComments
               projectId={projectId}
               comments={comments || []}

--- a/apps/web/app/(public)/launches/page.tsx
+++ b/apps/web/app/(public)/launches/page.tsx
@@ -73,24 +73,24 @@ function LaunchesPage() {
       <div className="fixed top-0 right-0 left-0 z-10 h-[32px] bg-[#101010]" />
       <div className="mx-auto min-h-screen max-w-[1080px] pt-20">
         <Tabs value={tab} onValueChange={setTab}>
-          <TabsList className="fixed top-[calc(32px+65px)] z-10 mb-6 flex w-full max-w-[calc(100vw-3rem)] lg:max-w-[1080px] rounded-none border border-t-0 border-[#404040] bg-[#262626]">
+          <TabsList className="fixed top-[calc(32px+65px)] z-10 mb-6 flex w-full max-w-[calc(100vw-3rem)] rounded-none border border-t-0 border-[#404040] bg-[#262626] lg:max-w-[1080px]">
             <TabsTrigger
               value="today"
-    className="flex shrink items-center gap-2 rounded-none text-xs sm:text-base data-[state=active]:!bg-neutral-900/60"
+              className="flex shrink items-center gap-2 rounded-none text-xs data-[state=active]:!bg-neutral-900/60 sm:text-base"
             >
               <Calendar className="h-4 w-4" />
               Today
             </TabsTrigger>
             <TabsTrigger
               value="yesterday"
-    className="flex shrink items-center gap-2 rounded-none text-xs sm:text-base data-[state=active]:!bg-neutral-900/60"
+              className="flex shrink items-center gap-2 rounded-none text-xs data-[state=active]:!bg-neutral-900/60 sm:text-base"
             >
               <TrendingUp className="h-4 w-4" />
               Yesterday
             </TabsTrigger>
             <TabsTrigger
               value="all"
-    className="flex shrink items-center gap-2 rounded-none text-xs sm:text-base data-[state=active]:!bg-neutral-900/60"
+              className="flex shrink items-center gap-2 rounded-none text-xs data-[state=active]:!bg-neutral-900/60 sm:text-base"
             >
               <TrendingUp className="h-4 w-4" />
               All Launches

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -28,6 +28,8 @@ export function LoginForm({
   // });
 
   const signInWithProvider = async (providerId: ProviderId) => {
+    console.log('[LoginForm] Sign in with:', providerId);
+    console.log('[LoginForm] Redirect URL:', redirectUrl);
     if (env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
       toast.error('This feature is not available in production');
       return;


### PR DESCRIPTION
## Description

This PR introduces logic to preserve the redirect URL when a logged-out user attempts a protected action. Instead of sending them to the default landing page after login, they are redirected to the page they originally intended to visit using a `?redirect=/launches/{launchId}` query parameter.

### Example Flow:

* User is not logged in
* User visits `/launches/abc123` directly or via a protected action
* User is redirected to `/login?redirect=/launches/abc123`
* After login, they are redirected to `/launches/abc123`

This improves user experience by keeping them on their intended flow.

## Type of Change

* [x] ✨ New feature

## Testing

* [x] I have tested my changes locally and verified redirect works as expected

---

Closes #130


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The login page now supports redirecting users after login based on a URL parameter.
  * Launch detail pages require users to be authenticated and will redirect unauthenticated users to the login page, preserving their intended destination.

* **Style**
  * Improved the order of CSS classes for more consistent styling on the launches page.

* **Chores**
  * Added console log statements to aid in debugging login and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->