### PR TITLE
fix:issue  #160 profile page contribution not working

### DIFF
--- a/packages/api/src/driver/github.ts
+++ b/packages/api/src/driver/github.ts
@@ -617,7 +617,7 @@ export class GithubManager implements GitManager {
     const stateFilter = options?.state || 'all';
 
     return getCached(
-      createCacheKey('github', 'user_pull_requests', username),
+      createCacheKey('github', 'user_pull_requests', `${username}_${stateFilter}_${limit}`),
       async () => {
         // Start with a simpler query and add fields progressively
         const query = `
@@ -732,9 +732,10 @@ export class GithubManager implements GitManager {
               },
             }));
 
+            // Apply filtering logic based on state
             const filteredPRs = formattedPRs.filter((pr) => {
               if (stateFilter === 'all') return true;
-              if (stateFilter === 'open') return pr.state === 'open';
+              if (stateFilter === 'open') return pr.state === 'open' && !pr.mergedAt;
               if (stateFilter === 'closed') return pr.state === 'closed' && !pr.mergedAt;
               if (stateFilter === 'merged') return !!pr.mergedAt;
               return true;


### PR DESCRIPTION

This PR fixes the backend issues with contribution filtering by state (Open, Merged, Closed, All) on the Profile page.
---
## Type of Change
✅ Changes Made
1. Cache Key Fixes
 - Updated cache keys in both GitHub and GitLab drivers to include:

2. Improved Filtering Logic
- Open: PRs that are open and not merged
- Closed: PRs that are closed and not merged
- Merged: PRs that are merged (regardless of state)
- All: Includes all PRs

3. GitHub Driver
- Fixed filtering to properly distinguish between open, closed, and merged PRs
- Updated cache key handling
