### PR TITLE
fix: mobile overflow on contributions tab branch names (#95)

### DIFF
--- a/apps/web/components/user/profile-tabs.tsx
+++ b/apps/web/components/user/profile-tabs.tsx
@@ -474,13 +474,13 @@ function UserPullRequests({ profile }: { profile: Profile }) {
                         </div>
                       </div>
                       {pr.headRefName && (
-                        <div className="mt-2 flex items-center justify-between gap-2 text-xs text-neutral-500">
-                          <div className="flex items-center gap-2">
-                            <code className="rounded-none bg-neutral-800 px-1.5 py-0.5">
+                        <div className="mt-2 flex flex-col gap-2 text-xs text-neutral-500 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                            <code className="min-w-0 rounded-none bg-neutral-800 px-1.5 py-0.5 [overflow-wrap:break-word] [word-break:break-word] [hyphens:auto]">
                               {pr.headRefName}
                             </code>
-                            <span>→</span>
-                            <code className="rounded-none bg-neutral-800 px-1.5 py-0.5">
+                            <span className="shrink-0">→</span>
+                            <code className="min-w-0 rounded-none bg-neutral-800 px-1.5 py-0.5 [overflow-wrap:break-word] [word-break:break-word] [hyphens:auto]">
                               {pr.baseRefName}
                             </code>
                           </div>


### PR DESCRIPTION
## Description

Brief description of what this PR does:

fix mobile overflow on contributions tab in profile page by implementing responsive flex layout that stacks vertically on mobile and text wrapping on branch names

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ⚡ Performance improvement
- [ ] Other (please describe)

## Testing

- [x ] I have tested my changes locally

## Checklist

- [x] My code follows the project style
- [] I've updated relevant documentation (no documentation needed)

## Screenshots (if applicable)

### Before

<img width="361" height="324" alt="Screenshot 2025-08-12 at 12 58 54 AM" src="https://github.com/user-attachments/assets/cad4efa7-e750-487d-949e-ffc4acda2f6e" />

overflow seen here
<img width="448" height="420" alt="Screenshot 2025-08-12 at 12 59 21 AM" src="https://github.com/user-attachments/assets/0536943f-8250-476a-a7cb-451af55e3aff" />


### After

<img width="430" height="472" alt="Screenshot 2025-08-12 at 12 56 32 AM" src="https://github.com/user-attachments/assets/000c9a03-8e4f-47db-b48a-d8a2827ee6b2" />

<img width="425" height="345" alt="Screenshot 2025-08-12 at 12 55 39 AM" src="https://github.com/user-attachments/assets/0dba00f2-7051-419e-a5d7-9d5ae552bde0" />

---

_Please ensure your PR title clearly describes the change._
