### PR TITLE
Add user profile about section with README support for GitHub and GitLab

### DIFF
--- a/apps/web/app/(public)/(projects)/projects/[id]/project-page.tsx
+++ b/apps/web/app/(public)/(projects)/projects/[id]/project-page.tsx
@@ -33,12 +33,7 @@ import { useEffect, useState, useRef } from 'react';
 import Link from '@workspace/ui/components/link';
 import { useTRPC } from '@/hooks/use-trpc';
 import { formatDate } from '@/lib/utils';
-
-// Define types for repository data
-interface RepoContent {
-  content: string;
-  encoding: 'base64' | 'utf8';
-}
+import {isValidProvider, RepoContent} from '@/lib/constants'
 
 interface Label {
   id: string | number;
@@ -148,12 +143,6 @@ interface RepoData {
 //     };
 //   }>;
 // }
-
-const isValidProvider = (
-  provider: string | null | undefined,
-): provider is (typeof projectProviderEnum.enumValues)[number] => {
-  return provider === 'github' || provider === 'gitlab';
-};
 
 function useProject(id: string) {
   const trpc = useTRPC();

--- a/apps/web/app/(public)/(projects)/projects/project-card.tsx
+++ b/apps/web/app/(public)/(projects)/projects/project-card.tsx
@@ -5,14 +5,9 @@ import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/hooks/use-trpc';
 import { formatDate } from '@/lib/utils';
 import Image from 'next/image';
+import {isValidProvider} from '@/lib/constants'
 
 type Project = typeof projectSchema.$inferSelect;
-
-const isValidProvider = (
-  provider: string | null,
-): provider is (typeof projectProviderEnum.enumValues)[number] => {
-  return provider === 'github' || provider === 'gitlab';
-};
 
 export default function ProjectCard({
   project,

--- a/apps/web/app/(public)/launches/[id]/components/launch-header.tsx
+++ b/apps/web/app/(public)/launches/[id]/components/launch-header.tsx
@@ -7,12 +7,7 @@ import { authClient } from '@workspace/auth/client';
 import { Flag, Share2 } from 'lucide-react';
 import { useTRPC } from '@/hooks/use-trpc';
 import { toast } from 'sonner';
-
-const isValidProvider = (
-  provider: string | null | undefined,
-): provider is (typeof projectProviderEnum.enumValues)[number] => {
-  return provider === 'github' || provider === 'gitlab';
-};
+import {isValidProvider} from '@/lib/constants'
 
 interface LaunchHeaderProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web/app/(public)/launches/[id]/components/launch-sidebar.tsx
+++ b/apps/web/app/(public)/launches/[id]/components/launch-sidebar.tsx
@@ -34,12 +34,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { useTRPC } from '@/hooks/use-trpc';
 import { useState } from 'react';
 import { toast } from 'sonner';
-
-const isValidProvider = (
-  provider: string | null | undefined,
-): provider is (typeof projectProviderEnum.enumValues)[number] => {
-  return provider === 'github' || provider === 'gitlab';
-};
+import {isValidProvider} from '@/lib/constants'
 
 interface LaunchSidebarProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web/app/(public)/launches/launch-card.tsx
+++ b/apps/web/app/(public)/launches/launch-card.tsx
@@ -13,12 +13,7 @@ import { formatDate } from '@/lib/utils';
 import { motion } from 'motion/react';
 import Image from 'next/image';
 import { toast } from 'sonner';
-
-const isValidProvider = (
-  provider: string | null,
-): provider is (typeof projectProviderEnum.enumValues)[number] => {
-  return provider === 'github' || provider === 'gitlab';
-};
+import {isValidProvider} from '@/lib/constants'
 
 const getRankBadge = (index: number) => {
   if (index === 0)

--- a/apps/web/components/user/profile-tabs.tsx
+++ b/apps/web/components/user/profile-tabs.tsx
@@ -6,7 +6,7 @@ import {
   SelectValue,
 } from '@workspace/ui/components/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@workspace/ui/components/tabs';
-import { Heart, TrendingUp, GitFork, Clock, ExternalLink } from 'lucide-react';
+import { Heart, TrendingUp, GitFork, Clock, ExternalLink, FileText } from 'lucide-react';
 import ProjectCard from '@/app/(public)/(projects)/projects/project-card';
 import { Card, CardContent } from '@workspace/ui/components/card';
 import { Skeleton } from '@workspace/ui/components/skeleton';
@@ -24,6 +24,7 @@ import { useTRPC } from '@/hooks/use-trpc';
 import { useQueryState } from 'nuqs';
 import { UnSubmittedRepo } from '@workspace/api';
 import UnsubmittedRepoCard from './unsubmitted-project-card';
+import { MarkdownContent } from '@/components/project/markdown-content';
 
 interface Profile {
   git?: {
@@ -53,6 +54,7 @@ interface PullRequestData {
 }
 
 interface ProfileTabsProps {
+  profileReadme:any;
   profile: Profile | undefined;
   isProfileLoading: boolean;
   tab: string;
@@ -63,6 +65,7 @@ interface ProfileTabsProps {
 }
 
 export function ProfileTabs({
+  profileReadme,
   profile,
   isProfileLoading,
   tab,
@@ -116,7 +119,10 @@ export function ProfileTabs({
         <ContributionGraph username={profile.git.login} provider={profile.git.provider} />
       )}
       <Tabs defaultValue={tab} onValueChange={setTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-4 rounded-none border-neutral-800 bg-neutral-900/50">
+        <TabsList className="grid w-full grid-cols-5 rounded-none border-neutral-800 bg-neutral-900/50">
+          <TabsTrigger value="about" className="rounded-none">
+            About
+          </TabsTrigger>
           <TabsTrigger value="projects" className="rounded-none">
             Projects
           </TabsTrigger>
@@ -130,6 +136,37 @@ export function ProfileTabs({
             Collections
           </TabsTrigger>
         </TabsList>
+        <TabsContent value="about" className="mt-2">
+          {profileReadme ? (
+            <div className="rounded-none border border-neutral-800 bg-neutral-900/50 p-6">
+              <MarkdownContent
+                content={profileReadme.content}
+                encoding={
+                  profileReadme.encoding === 'base64' || profileReadme.encoding === 'utf8'
+                    ? profileReadme.encoding
+                    : 'base64'
+                }
+              />
+            </div>
+          ) : (
+            <div className="rounded-none border border-neutral-800 bg-neutral-900/50 p-6">
+              <div className="py-8 text-center">
+                <FileText className="mx-auto mb-4 h-12 w-12 text-neutral-600" />
+                <h3 className="mb-2 text-lg font-medium text-neutral-300">
+                  No README found
+                </h3>
+                <p className="mx-auto mb-4 max-w-md text-sm text-neutral-400">
+                  A README file typically contains information about the project, how to
+                  install and use it, and other important details for users and
+                  contributors.
+                </p>
+                <p className="text-xs text-neutral-500">
+                  Common filenames: README.md, README.rst, README.txt
+                </p>
+              </div>
+            </div>
+          )}
+        </TabsContent>
 
         <TabsContent value="projects" className="mt-2">
           {featuredProjects.length > 0 ? (

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,4 +1,5 @@
 import Icons from '@workspace/ui/components/icons';
+import { projectProviderEnum } from '@workspace/db/schema';
 
 export const providers = [
   {
@@ -14,3 +15,14 @@ export const providers = [
 ];
 
 export type ProviderId = (typeof providers)[number]['providerId'];
+
+export const isValidProvider = (
+  provider: string | null | undefined,
+): provider is (typeof projectProviderEnum.enumValues)[number] => {
+  return provider === 'github' || provider === 'gitlab';
+};
+
+export interface RepoContent {
+  content: string;
+  encoding: 'base64' | 'utf8';
+}


### PR DESCRIPTION
## Description

Brief description of what this PR does:
This PR adds a new "about" section to user profiles that displays the user's README file. The feature supports both GitHub and GitLab providers. It also refactors existing constants, interfaces, and functions like `RepoContent `and `isValidProvider `by moving them to the lib/constants file instead of redeclaring them throughout the codebase.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ⚡ Performance improvement
- [ ] Other (please describe)

## Testing

- [x] I have tested my changes locally

## Checklist

- [x] My code follows the project style
- [ ] I've updated relevant documentation

## Screenshots (if applicable)

<img width="1092" height="344" alt="image" src="https://github.com/user-attachments/assets/f3fa2bba-99e5-4279-9b09-74d609c07fe8" />

---

_Please ensure your PR title clearly describes the change._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an About tab on user profiles that displays the user’s README with Markdown rendering when available.
  - Shows a helpful fallback message when no README is found.

- Changes
  - Default profile tab now opens to About.

- Refactor
  - Centralized repository provider validation and content typing across project and launch views with no user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->