### PR TITLE
fix: prevent "No README found" flash with loading skeleton

### DIFF
--- a/apps/web/components/user/profile-tabs.tsx
+++ b/apps/web/components/user/profile-tabs.tsx
@@ -25,6 +25,7 @@ import { useQueryState } from 'nuqs';
 import { UnSubmittedRepo } from '@workspace/api';
 import UnsubmittedRepoCard from './unsubmitted-project-card';
 import { MarkdownContent } from '@/components/project/markdown-content';
+import { RepoContent } from '@/lib/constants';
 
 interface Profile {
   git?: {
@@ -54,7 +55,8 @@ interface PullRequestData {
 }
 
 interface ProfileTabsProps {
-  profileReadme:any;
+  isReadmeLoading: boolean;
+  profileReadme: RepoContent | null;
   profile: Profile | undefined;
   isProfileLoading: boolean;
   tab: string;
@@ -65,6 +67,7 @@ interface ProfileTabsProps {
 }
 
 export function ProfileTabs({
+  isReadmeLoading,
   profileReadme,
   profile,
   isProfileLoading,
@@ -148,17 +151,26 @@ export function ProfileTabs({
                 }
               />
             </div>
+          ) : isReadmeLoading ? (
+            <Card className="rounded-none border-neutral-800 bg-neutral-900/50 p-0">
+              <CardContent className="p-6">
+                <div className="space-y-4">
+                  <Skeleton className="h-5 w-3/4 rounded-none" />
+                  <Skeleton className="h-4 w-1/2 rounded-none" />
+                  <Skeleton className="h-4 w-5/6 rounded-none" />
+                  <Skeleton className="h-4 w-2/3 rounded-none" />
+                  <Skeleton className="h-4 w-4/5 rounded-none" />
+                </div>
+              </CardContent>
+            </Card>
           ) : (
             <div className="rounded-none border border-neutral-800 bg-neutral-900/50 p-6">
               <div className="py-8 text-center">
                 <FileText className="mx-auto mb-4 h-12 w-12 text-neutral-600" />
-                <h3 className="mb-2 text-lg font-medium text-neutral-300">
-                  No README found
-                </h3>
+                <h3 className="mb-2 text-lg font-medium text-neutral-300">No README found</h3>
                 <p className="mx-auto mb-4 max-w-md text-sm text-neutral-400">
-                  A README file typically contains information about the project, how to
-                  install and use it, and other important details for users and
-                  contributors.
+                  A profile README typically includes a short bio, interests, skills, and links to
+                  notable projects or socials.
                 </p>
                 <p className="text-xs text-neutral-500">
                   Common filenames: README.md, README.rst, README.txt

--- a/apps/web/components/user/profile.tsx
+++ b/apps/web/components/user/profile.tsx
@@ -70,31 +70,21 @@ export default function ProfilePage({ id }: { id: string }) {
     return `https://${url}`;
   };
 
-  const [profileReadme, setProfileReadme] = useState<RepoContent | null >(null);
-
-// 2️⃣ TRPC query to fetch profile README
-const readmeQuery = useQueries({
-  queries: [
+  const {
+    data: profileReadme,
+    isPending: isReadmeLoading,
+  } = useQuery(
     trpc.repository.getReadme.queryOptions(
       {
-        url: `${profile?.username}/${profile?.username}`, // repo name = username
-        provider: profile?.git?.provider  as (typeof projectProviderEnum.enumValues)[number],
+        url: `${profile?.username}/${profile?.username}`,
+        provider: profile?.git?.provider as (typeof projectProviderEnum.enumValues)[number],
       },
       {
-        enabled: !!profile?.username && isValidProvider(profile?.git.provider),
+        enabled: !!profile?.username && isValidProvider(profile?.git?.provider),
         retry: false,
-      }
+      },
     ),
-  ],
-});
-
-
-// 3️⃣ Update state when query finishes
-useEffect(() => {
-  if (readmeQuery?.[0]?.data) {
-    setProfileReadme(readmeQuery[0].data as RepoContent);
-  }
-}, [readmeQuery]);
+  );
 
   const projectQueries = useQueries({
     queries: (projects?.data || []).map((project) => {
@@ -278,6 +268,7 @@ useEffect(() => {
 
             <div className="space-y-4 lg:col-span-8">
               <ProfileTabs
+                isReadmeLoading={isReadmeLoading}
                 profileReadme={profileReadme}
                 profile={profile}
                 isProfileLoading={isProfileLoading}


### PR DESCRIPTION
## Description

Brief description of what this PR does:

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ⚡ Performance improvement
- [ ] Other (please describe)

## Testing

- [x] I have tested my changes locally

## Checklist

- [x] My code follows the project style
- [ ] I've updated relevant documentation

## Screenshots (if applicable)


---

_Please ensure your PR title clearly describes the change._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a loading state for the profile README, showing a skeleton while content loads.
  * Improved empty-state behavior: displays a clear “No README found” message with guidance.
* Style
  * Refined empty-state UI with a concise header.
  * Updated descriptive copy to reference profile README details (bio, interests, links).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->