### PR TITLE
fix: prevent form dialogs from closing on outside click

### DIFF
--- a/apps/web/components/project/launch-project-dialog.tsx
+++ b/apps/web/components/project/launch-project-dialog.tsx
@@ -295,7 +295,11 @@ export function LaunchProjectDialog({
   // Private Repository Dialog
   const PrivateRepoDialog = () => (
     <Dialog open={privateRepoDialogOpen} onOpenChange={setPrivateRepoDialogOpen}>
-      <DialogContent className="rounded-none sm:max-w-[500px]">
+      <DialogContent
+        className="rounded-none sm:max-w-[500px]"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertCircle className="h-5 w-5 text-yellow-500" />
@@ -404,7 +408,11 @@ export function LaunchProjectDialog({
               Launch Project
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-h-[80vh] overflow-y-auto rounded-none sm:max-w-[600px]">
+          <DialogContent
+            className="max-h-[80vh] overflow-y-auto rounded-none sm:max-w-[600px]"
+            onPointerDownOutside={(e) => e.preventDefault()}
+            onEscapeKeyDown={(e) => e.preventDefault()}
+          >
             <DialogHeader>
               <DialogTitle>Launch {projectName}</DialogTitle>
               <DialogDescription>

--- a/apps/web/components/submissions/early-submission-dialog.tsx
+++ b/apps/web/components/submissions/early-submission-dialog.tsx
@@ -30,7 +30,11 @@ export default function EarlySubmissionDialog() {
           <ArrowRight className="h-4 w-4" />
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto rounded-none">
+      <DialogContent
+        className="max-h-[90vh] max-w-2xl overflow-y-auto rounded-none"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Early Submission</DialogTitle>
           <DialogDescription>Submit your open source project for early access.</DialogDescription>

--- a/apps/web/components/submissions/submission-dialog.tsx
+++ b/apps/web/components/submissions/submission-dialog.tsx
@@ -44,7 +44,11 @@ export default function SubmissionDialog({ quickSubmit }: SubmissionDialogProps)
           Submit Project
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto rounded-none">
+      <DialogContent
+        className="max-h-[90vh] max-w-2xl overflow-y-auto rounded-none"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Submit Project</DialogTitle>
           <DialogDescription>Submit an open source project.</DialogDescription>


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where clicking outside form dialogs would dismiss them and lose all filled information.

## Problem
- Users would fill out project submission forms
- Accidentally click outside the dialog
- Dialog would close and all data would be lost
- Users had to restart the entire submission process

## Solution
Added `onPointerDownOutside` and `onEscapeKeyDown` event handlers to prevent outside clicks and escape key from closing form dialogs.

## Changes Made
- **submission-dialog.tsx**: Added prevent outside click handlers
- **early-submission-dialog.tsx**: Added prevent outside click handlers  
- **launch-project-dialog.tsx**: Added prevent outside click handlers
- **launch-project-dialog.tsx**: Also fixed private repo dialog

## Testing
- [x] Submit project dialog boxs no longer closes on outside click
- [x] Only X button and form submission can close dialogs

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Severity
Moderate - Feature was partially broken, users could lose form data

## Screenshots

https://github.com/user-attachments/assets/a72512ca-cfbb-4859-9898-a91ab91a7613

